### PR TITLE
fix: actually remove potential exploiters from rektdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the code to reproduce the data used after the v9 incide
 
 | Data                                 | Description                                                              |
 |--------------------------------------|--------------------------------------------------------------------------|
-| [analysis](./analsysis.ipynb) | Download and process all relevant transactions from `4707300` to halt `4713064` |
+| [analysis](./analysis.ipynb) | Download and process all relevant transactions from `4707300` to halt `4713064` |
 
 
 ## Quickstart

--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -2643,7 +2643,7 @@
     "\n",
     "# remove addresses that have done more than 1 join and 1 exit on a pool\n",
     "# (i.e. possible exploiters) from any airdrop\n",
-    "rektdrop_df[~rektdrop_df.address.isin([\n",
+    "rektdrop_df = rektdrop_df[~rektdrop_df.address.isin([\n",
     "    \"osmo1yglld3aary7lnrrn2dz7la84kmnmen4kpsxzay\",\n",
     "    \"osmo1pfpk6rsgc0x7g8q7y0yre86ej2enr8rhv3p8dq\",\n",
     "    \"osmo1jdh7eeyaar0tyask0r6w2228uh5wrd0pxtcfwr\",\n",


### PR DESCRIPTION
The final address-based filtration was not finalized as the value was not assigned back to `rektdrop_df`. This fixes that.